### PR TITLE
Add hardhat-abi-exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.json
 typechain
 cache
 artifacts
+abis

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,11 +1,12 @@
 import * as dotenv from "dotenv";
 
-import { HardhatUserConfig, task } from "hardhat/config";
+import type { HardhatUserConfig } from "hardhat/types/config";
 import "@nomiclabs/hardhat-etherscan";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "hardhat-abi-exporter";
 
 dotenv.config();
 
@@ -29,8 +30,7 @@ const config: HardhatUserConfig = {
   networks: {
     ropsten: {
       url: process.env.ROPSTEN_URL || "",
-      accounts:
-        process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+      accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
     },
   },
   gasReporter: {
@@ -41,7 +41,13 @@ const config: HardhatUserConfig = {
     apiKey: process.env.ETHERSCAN_API_KEY,
   },
   typechain: {
-    outDir: 'typechain',
+    outDir: "typechain",
+  },
+  abiExporter: {
+    path: "./abis/",
+    runOnCompile: true,
+    clear: true,
+    pretty: false,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
   "name": "metastreet-contracts",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "metastreet-contracts",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
       "dependencies": {
         "@openzeppelin/contracts": "^4.4.2",
         "@openzeppelin/contracts-upgradeable": "^4.4.2",
@@ -34,6 +38,7 @@
         "ethereum-waffle": "^3.4.0",
         "ethers": "^5.5.3",
         "hardhat": "^2.8.3",
+        "hardhat-abi-exporter": "^2.8.0",
         "hardhat-gas-reporter": "^1.0.7",
         "prettier": "^2.5.1",
         "prettier-plugin-solidity": "^1.0.0-beta.13",
@@ -4237,6 +4242,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delete-empty": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/delete-empty/-/delete-empty-3.0.0.tgz",
+      "integrity": "sha512-ZUyiwo76W+DYnKsL3Kim6M/UOavPdBJgDYWOmuQhYaZvJH0AXAHbUNyEDtRbBra8wqqr686+63/0azfEk1ebUQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.0",
+        "minimist": "^1.2.0",
+        "path-starts-with": "^2.0.0",
+        "rimraf": "^2.6.2"
+      },
+      "bin": {
+        "delete-empty": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/delete-empty/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/depd": {
@@ -15697,6 +15732,22 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/hardhat-abi-exporter": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/hardhat-abi-exporter/-/hardhat-abi-exporter-2.8.0.tgz",
+      "integrity": "sha512-HQwd9Agr2O5znUg9Dzicw8grsXacoMSQsS5ZhBBNyaxKeVbvxL1Ubm9ss8sSVGr74511a8qiR2Ljm/lsLS9Mew==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.5.0",
+        "delete-empty": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
+      }
+    },
     "node_modules/hardhat-gas-reporter": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.8.tgz",
@@ -18755,6 +18806,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-starts-with": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-2.0.0.tgz",
+      "integrity": "sha512-3UHTHbJz5+NLkPafFR+2ycJOjoc4WV2e9qCZCnm71zHiWaFrm1XniLVTkZXvaRgxr1xFh9JsTdicpH2yM03nLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -26670,6 +26730,29 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delete-empty": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/delete-empty/-/delete-empty-3.0.0.tgz",
+      "integrity": "sha512-ZUyiwo76W+DYnKsL3Kim6M/UOavPdBJgDYWOmuQhYaZvJH0AXAHbUNyEDtRbBra8wqqr686+63/0azfEk1ebUQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.0",
+        "minimist": "^1.2.0",
+        "path-starts-with": "^2.0.0",
+        "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "depd": {
       "version": "1.1.2",
@@ -35682,6 +35765,16 @@
         }
       }
     },
+    "hardhat-abi-exporter": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/hardhat-abi-exporter/-/hardhat-abi-exporter-2.8.0.tgz",
+      "integrity": "sha512-HQwd9Agr2O5znUg9Dzicw8grsXacoMSQsS5ZhBBNyaxKeVbvxL1Ubm9ss8sSVGr74511a8qiR2Ljm/lsLS9Mew==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.5.0",
+        "delete-empty": "^3.0.0"
+      }
+    },
     "hardhat-gas-reporter": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.8.tgz",
@@ -37931,6 +38024,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-starts-with": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-2.0.0.tgz",
+      "integrity": "sha512-3UHTHbJz5+NLkPafFR+2ycJOjoc4WV2e9qCZCnm71zHiWaFrm1XniLVTkZXvaRgxr1xFh9JsTdicpH2yM03nLA==",
       "dev": true
     },
     "path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,18 @@
 {
+  "version": "0.1.0",
+  "name": "metastreet-contracts",
+  "description": "",
+  "main": "",
+  "author": "",
+  "license": "UNLICENSED",
+  "files": [
+    "contracts/interfaces",
+    "contracts/*",
+    "artifacts/@openzeppelin/contracts/**/*.json",
+    "artifacts/contracts/interfaces/**/*.json",
+    "!artifacts/contracts/interfaces/**/*.dbg.json",
+    "!artifacts/@openzeppelin/contracts/**/*.dbg.json"
+  ],
   "scripts": {
     "build": "hardhat compile",
     "clean": "hardhat clean",
@@ -9,7 +23,8 @@
     "format": "prettier --write 'contracts/**/*.sol'",
     "format:ts": "prettier --write '{test,scripts}/**/*.ts'",
     "analyze": "slither --filter-paths 'node_modules|contracts/test' .",
-    "node": "hardhat node"
+    "node": "hardhat node",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.5.0",
@@ -36,6 +51,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.3",
     "hardhat": "^2.8.3",
+    "hardhat-abi-exporter": "^2.8.0",
     "hardhat-gas-reporter": "^1.0.7",
     "prettier": "^2.5.1",
     "prettier-plugin-solidity": "^1.0.0-beta.13",


### PR DESCRIPTION
I needed only the ABIs generated in a given folder in the package, so I could use it to generate the typechain code in the frontend. This way I can keep the typechain helpers in the frontend and compile them for the library that will be used in the app to access the smart contracts.

What we’d need on the frontend is a proper way to import the ABIs essentially. I think an NPM package would be the best, or we can even do it through a Github URL as implemented [here](https://github.com/metastreet-labs/metastreet-frontend/commit/ac826a62f75d76fa2c708df91a283680403e842e). However, if other options could work too e.g. copying the ABIs into the frontend and committing them there.
If we stick with adding it as a `devDependency` to the frontend, then we’d need to make the contracts repo an actual package with a version, description, name and others in the package.json, and every time the ABIs get updated we’d need publish an update to the package or just increment the version number, otherwise, npm install will not update it.

